### PR TITLE
add dep role in readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ ansible-galaxy collection install a2dev.general:==0.1.0
 
 See [using Ansible collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
 
+You can olso install all python dependencies via role:
+
+```yaml
+  - name: Install Dependencies on CN
+    hosts: all
+    gather_facts: no
+    roles:
+      - role: a2dev.general.install_dep
+```
+```yaml
+  # install in pre_tasks with become: false
+  - name: Install Dependencies on CN
+    hosts: all
+    gather_facts: no
+
+    pre_tasks:
+
+      - name: install dependencies
+        block:
+          - include_role:
+              name: a2dev.general.install_dep
+        become: false
+```
+
 ## Release notes
 
 See the [changelog](https://github.com/3A2DEV/a2dev.general/tree/main/CHANGELOG.rst).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR add **`a2dev.general.install_dep`** in **`readme`** description

```yaml
  - name: Install Dependencies on CN
    hosts: all
    gather_facts: no
    roles:
      - role: a2dev.general.install_dep
```
```yaml
  # install in pre_tasks with become: false
  - name: Install Dependencies on CN
    hosts: all
    gather_facts: no

    pre_tasks:

      - name: install dependencies
        block:
          - include_role:
              name: a2dev.general.install_dep
        become: false
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```